### PR TITLE
SIK-2598: Optional location for events

### DIFF
--- a/gundi_core/schemas/v2.py
+++ b/gundi_core/schemas/v2.py
@@ -125,7 +125,7 @@ class Event(GundiBaseModel):
         title="Timestamp for the data, preferrably in ISO format.",
         example="2021-03-21 12:01:02-0700",
     )
-    location: Location
+    location: Optional[Location]
     title: Optional[str] = Field(
         None,
         title="Event title",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.2.6"
+version = "1.2.7"
 
 description = ""
 authors = [


### PR DESCRIPTION
### What does this PR do?
Make the location optional in events v2, in order to support routing events coming for ER Analyzers in Gundi.

### Relevant link(s)
[SIK-2598](https://allenai.atlassian.net/browse/SIK-2598)

[SIK-2598]: https://allenai.atlassian.net/browse/SIK-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ