### PR TITLE
Fix patrol segment date fields in v1 model.

### DIFF
--- a/gundi_core/schemas/v1.py
+++ b/gundi_core/schemas/v1.py
@@ -310,8 +310,8 @@ class ERPatrolSegment(BaseModel):
     id: str
     leader: Optional[ERSubject]
     patrol_type: str
-    schedule_start: Optional[dict]
-    schedule_end: Optional[dict]
+    scheduled_start: Optional[datetime]
+    scheduled_end: Optional[datetime]
     start_location: Optional[ERLocation]
     time_range: Optional[dict]
     updates: Optional[List[ERUpdate]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.2.9"
+version = "1.2.10"
 
 description = ""
 authors = [


### PR DESCRIPTION
This fixes a name error in ERPatrolSegment where we find the `scheduled_start` and `scheduled_end` date properties.
See: [GUNDI-2316 Patrol dates are not recorded in Smart Connect](https://allenai.atlassian.net/browse/GUNDI-2316)