### PR TITLE
GUNDI-3145: Activity logs for Webhooks

### DIFF
--- a/gundi_core/events/integrations.py
+++ b/gundi_core/events/integrations.py
@@ -71,11 +71,11 @@ class IntegrationWebhookEvent(BaseModel):
     )
 
 
-class WebhookExecutionStarted(IntegrationActionEvent):
+class WebhookExecutionStarted(IntegrationWebhookEvent):
     pass
 
 
-class WebhookExecutionComplete(IntegrationActionEvent):
+class WebhookExecutionComplete(IntegrationWebhookEvent):
     result: Optional[Dict[str, Any]] = Field(
         None,
         title="Result",
@@ -83,7 +83,7 @@ class WebhookExecutionComplete(IntegrationActionEvent):
     )
 
 
-class WebhookExecutionFailed(IntegrationActionEvent):
+class WebhookExecutionFailed(IntegrationWebhookEvent):
     error: Optional[str] = Field(
         "",
         title="Error",
@@ -92,6 +92,24 @@ class WebhookExecutionFailed(IntegrationActionEvent):
 
 
 class CustomActivityLog(IntegrationActionEvent):
+    title: str = Field(
+        "Custom Log",
+        title="Title",
+        description="A string with the title of the log.",
+    )
+    level: LogLevel = Field(
+        LogLevel.INFO,
+        title="Log Level",
+        description="The level of the log.",
+    )
+    data: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Extra Data",
+        description="A dictionary with extra data to be logged.",
+    )
+
+
+class CustomWebhookLog(IntegrationWebhookEvent):
     title: str = Field(
         "Custom Log",
         title="Title",
@@ -126,7 +144,7 @@ class IntegrationActionFailed(SystemEventBaseModel):
 
 
 class IntegrationWebhookCustomLog(SystemEventBaseModel):
-    payload: CustomActivityLog
+    payload: CustomWebhookLog
 
 
 class IntegrationWebhookStarted(SystemEventBaseModel):

--- a/gundi_core/events/integrations.py
+++ b/gundi_core/events/integrations.py
@@ -52,6 +52,45 @@ class ActionExecutionFailed(IntegrationActionEvent):
         description="A string with the error message of the action execution.",
     )
 
+
+class IntegrationWebhookEvent(BaseModel):
+    integration_id: Union[UUID, str] = Field(
+        None,
+        title="Integration ID",
+        description="The unique ID of the Integration.",
+    )
+    webhook_id: str = Field(
+        None,
+        title="Webhook Identifier",
+        description="A string identifier of the webhook of the related integration.",
+    )
+    config_data: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Configuration",
+        description="A dictionary with the configuration used to process the webhook request",
+    )
+
+
+class WebhookExecutionStarted(IntegrationActionEvent):
+    pass
+
+
+class WebhookExecutionComplete(IntegrationActionEvent):
+    result: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Result",
+        description="A dictionary with the result of the webhook execution.",
+    )
+
+
+class WebhookExecutionFailed(IntegrationActionEvent):
+    error: Optional[str] = Field(
+        "",
+        title="Error",
+        description="A string with the error message of the webhook execution.",
+    )
+
+
 class CustomActivityLog(IntegrationActionEvent):
     title: str = Field(
         "Custom Log",
@@ -84,3 +123,19 @@ class IntegrationActionComplete(SystemEventBaseModel):
 
 class IntegrationActionFailed(SystemEventBaseModel):
     payload: ActionExecutionFailed
+
+
+class IntegrationWebhookCustomLog(SystemEventBaseModel):
+    payload: CustomActivityLog
+
+
+class IntegrationWebhookStarted(SystemEventBaseModel):
+    payload: WebhookExecutionStarted
+
+
+class IntegrationWebhookComplete(SystemEventBaseModel):
+    payload: WebhookExecutionComplete
+
+
+class IntegrationWebhookFailed(SystemEventBaseModel):
+    payload: WebhookExecutionFailed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.4.0"
+version = "1.4.1"
 
 description = ""
 authors = [


### PR DESCRIPTION
### What does this PR do?
Adds pydantic models for activity events related to webhook integrations. These events are published by integrations and consumed by the portal.

### Relevant link(s)
[GUNDI-3145](https://allenai.atlassian.net/browse/GUNDI-3145)

[GUNDI-3145]: https://allenai.atlassian.net/browse/GUNDI-3145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ