### PR TITLE
GUNDI-3297: Event updates for SMART

### DIFF
--- a/gundi_core/events/__init__.py
+++ b/gundi_core/events/__init__.py
@@ -2,3 +2,4 @@ from .core import *
 from .dispatchers import *
 from .integrations import *
 from .gundi_api import *
+from .transformers import *

--- a/gundi_core/events/transformers.py
+++ b/gundi_core/events/transformers.py
@@ -1,9 +1,14 @@
-from gundi_core.schemas.v2 import EREvent, ERObservation, EREventUpdate, ERAttachment
+from gundi_core.schemas.v2 import (
+    EREvent, ERObservation, EREventUpdate, ERAttachment,
+    SMARTCompositeRequest, SMARTUpdateRequest
+)
 from .core import SystemEventBaseModel
+
 
 # Events published by the transformer service
 
 
+# Earth Ranger
 class EventTransformedER(SystemEventBaseModel):
     payload: EREvent
 
@@ -18,3 +23,12 @@ class AttachmentTransformedER(SystemEventBaseModel):
 
 class ObservationTransformedER(SystemEventBaseModel):
     payload: ERObservation
+
+
+# SMART
+class EventTransformedSMART(SystemEventBaseModel):
+    payload: SMARTCompositeRequest
+
+
+class EventUpdateTransformedSMART(SystemEventBaseModel):
+    payload: SMARTUpdateRequest

--- a/gundi_core/schemas/v2/__init__.py
+++ b/gundi_core/schemas/v2/__init__.py
@@ -1,0 +1,3 @@
+from .gundi import *
+from .earthranger import *
+from .smart import *

--- a/gundi_core/schemas/v2/earthranger.py
+++ b/gundi_core/schemas/v2/earthranger.py
@@ -1,0 +1,105 @@
+from typing import Optional, Dict, Any
+from datetime import datetime
+from pydantic import BaseModel, Field
+from .. import v1 as schemas_v1
+
+
+class EREventLocation(BaseModel):
+    longitude: float = Field(..., title="Longitude in decimal degrees")
+    latitude: float = Field(..., title="Latitude in decimal degrees")
+
+
+class EREvent(BaseModel):
+    title: str = Field(
+        None,
+        title="GeoEvent title",
+        description="Human-friendly title for this GeoEvent",
+    )
+    event_type: str = Field(
+        None, title="GeoEvent Type", description="Identifies the type of this GeoEvent"
+    )
+    time: datetime = Field(
+        ...,
+        title="Timestamp for the data, preferrably in ISO format.",
+        example="2021-03-21 12:01:02-0700",
+    )
+    location: Optional[EREventLocation]
+    event_details: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Additional Data",
+        description="A dictionary of extra data that will be passed to destination systems.",
+    )
+    geometry: Optional[Dict[str, Any]] = Field( # geojson???
+        None,
+        title="GeoEvent Geometry",
+        description="A dictionary containing details of this GeoEvent geoJSON.",
+    )
+    state: Optional[schemas_v1.EREventState]
+
+    class Config:
+        extra = "allow"  # To allow adding extra fields with field mappings
+
+
+class ERAttachment(BaseModel):
+    file_path: str
+
+    class Config:
+        extra = "allow"  # To allow adding extra fields with field mappings
+
+
+class ERObservationLocation(BaseModel):
+    lon: float = Field(..., title="Longitude in decimal degrees")
+    lat: float = Field(..., title="Latitude in decimal degrees")
+
+
+class ERObservation(BaseModel):
+    manufacturer_id: Optional[str] = Field(
+        "none",
+        example="901870234",
+        description="A unique identifier of the device associated with this data.",
+    )
+    source_type: Optional[str] = Field(
+        "tracking-device",
+        title="Type identifier for the associated device.",
+        example="gps-radio",
+    )
+    subject_name: Optional[str] = Field(
+        None,
+        title="An optional, human-friendly name for the subject.",
+        example="Security Vehicle A",
+    )
+    subject_type: Optional[str] = Field(
+        None,
+        title="Type identifier for the subject associated to this observation.",
+        example="vehicle",
+    )
+    subject_subtype: Optional[str] = Field(
+        None,
+        title="Suntype identifier for the subject associated to this observation.",
+        example="car",
+    )
+    recorded_at: datetime = Field(
+        ...,
+        title="Timestamp for the data, preferrably in ISO format.",
+        example="2021-03-21 12:01:02-0700",
+    )
+    location: Optional[ERObservationLocation]
+    additional: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Additional Data",
+        description="A dictionary of extra data that will be passed to destination systems.",
+    )
+
+    class Config:
+        extra = "allow"  # To allow adding extra fields with field mappings
+
+
+class EREventUpdate(BaseModel):
+    changes: Optional[Dict[str, Any]] = Field(
+        None,
+        title="ER Event Updates",
+        description="A dictionary containing the changes made to the ER event.",
+    )
+
+    class Config:
+        extra = "allow"  # To allow adding extra fields with field mappings

--- a/gundi_core/schemas/v2/gundi.py
+++ b/gundi_core/schemas/v2/gundi.py
@@ -4,7 +4,6 @@ from uuid import UUID
 from datetime import datetime, timezone
 from pydantic import BaseModel, Field, validator
 from enum import Enum
-from . import v1 as schemas_v1
 
 
 class StreamPrefixEnum(str, Enum):
@@ -840,107 +839,6 @@ class UpdatedObservation(BaseModel):
         description="The date and time when the update was sent to the destination system.",
         example="2023-06-23T12:01:02-0700",
     )
-
-
-class EREventLocation(BaseModel):
-    longitude: float = Field(..., title="Longitude in decimal degrees")
-    latitude: float = Field(..., title="Latitude in decimal degrees")
-
-
-class EREvent(BaseModel):
-    title: str = Field(
-        None,
-        title="GeoEvent title",
-        description="Human-friendly title for this GeoEvent",
-    )
-    event_type: str = Field(
-        None, title="GeoEvent Type", description="Identifies the type of this GeoEvent"
-    )
-    time: datetime = Field(
-        ...,
-        title="Timestamp for the data, preferrably in ISO format.",
-        example="2021-03-21 12:01:02-0700",
-    )
-    location: Optional[EREventLocation]
-    event_details: Optional[Dict[str, Any]] = Field(
-        None,
-        title="Additional Data",
-        description="A dictionary of extra data that will be passed to destination systems.",
-    )
-    geometry: Optional[Dict[str, Any]] = Field( # geojson???
-        None,
-        title="GeoEvent Geometry",
-        description="A dictionary containing details of this GeoEvent geoJSON.",
-    )
-    state: Optional[schemas_v1.EREventState]
-
-    class Config:
-        extra = "allow"  # To allow adding extra fields with field mappings
-
-
-class ERAttachment(BaseModel):
-    file_path: str
-
-    class Config:
-        extra = "allow"  # To allow adding extra fields with field mappings
-
-
-class ERObservationLocation(BaseModel):
-    lon: float = Field(..., title="Longitude in decimal degrees")
-    lat: float = Field(..., title="Latitude in decimal degrees")
-
-
-class ERObservation(BaseModel):
-    manufacturer_id: Optional[str] = Field(
-        "none",
-        example="901870234",
-        description="A unique identifier of the device associated with this data.",
-    )
-    source_type: Optional[str] = Field(
-        "tracking-device",
-        title="Type identifier for the associated device.",
-        example="gps-radio",
-    )
-    subject_name: Optional[str] = Field(
-        None,
-        title="An optional, human-friendly name for the subject.",
-        example="Security Vehicle A",
-    )
-    subject_type: Optional[str] = Field(
-        None,
-        title="Type identifier for the subject associated to this observation.",
-        example="vehicle",
-    )
-    subject_subtype: Optional[str] = Field(
-        None,
-        title="Suntype identifier for the subject associated to this observation.",
-        example="car",
-    )
-    recorded_at: datetime = Field(
-        ...,
-        title="Timestamp for the data, preferrably in ISO format.",
-        example="2021-03-21 12:01:02-0700",
-    )
-    location: Optional[ERObservationLocation]
-    additional: Optional[Dict[str, Any]] = Field(
-        None,
-        title="Additional Data",
-        description="A dictionary of extra data that will be passed to destination systems.",
-    )
-
-    class Config:
-        extra = "allow"  # To allow adding extra fields with field mappings
-
-
-class EREventUpdate(BaseModel):
-    changes: Optional[Dict[str, Any]] = Field(
-        None,
-        title="ER Event Updates",
-        description="A dictionary containing the changes made to the ER event.",
-    )
-
-    class Config:
-        extra = "allow"  # To allow adding extra fields with field mappings
 
 
 models_by_stream_type = {

--- a/gundi_core/schemas/v2/smart.py
+++ b/gundi_core/schemas/v2/smart.py
@@ -1,0 +1,216 @@
+import json
+import uuid
+from datetime import datetime, date
+from typing import List, Any, Optional, Union
+from pydantic import BaseModel, Field, parse_obj_as, validator
+
+
+SMARTCONNECT_DATFORMAT = '%Y-%m-%dT%H:%M:%S'
+
+
+class CategoryAttribute(BaseModel):
+    key: str
+    is_active: bool = Field(alias="isactive", default=True)
+
+
+class Category(BaseModel):
+    path: str
+    hkeyPath: Optional[str]
+    display: str
+    is_multiple: Optional[bool] = Field(alias="ismultiple", default=False)
+    is_active: Optional[bool] = Field(alias="isactive", default=True)
+    attributes: Optional[List[CategoryAttribute]]
+
+
+class AttributeOption(BaseModel):
+    key: str
+    display: str
+    is_active: Optional[bool] = Field(alias="isActive", default=True)
+
+
+class Attribute(BaseModel):
+    key: str
+    type: str
+    isrequired: Optional[bool] = False
+    display: str
+    options: Optional[List[AttributeOption]]
+
+
+class TransformationRule(BaseModel):
+    match_pattern: dict
+    transforms: dict
+
+
+class SmartObservation(BaseModel):
+    observationUuid: Optional[str]
+    category: str
+    attributes: dict
+
+    validator("observationUuid")
+
+    def clean_observationUuid(cls, val):
+        # TODO: Redress to make observationUuid a UUID field.
+        if val == 'None':
+            return None
+        return val
+
+
+class SmartObservationGroup(BaseModel):
+    observations: List[SmartObservation]
+
+
+class Geometry(BaseModel):
+    coordinates: List[float] = Field(..., max_item=2, min_items=2)
+
+
+class File(BaseModel):
+    filename: str
+    data: str
+    signatureType: Optional[str]
+
+
+class SmartAttributes(BaseModel):
+    observationGroups: Optional[List[SmartObservationGroup]]
+    patrolUuid: Optional[str]
+    patrolLegUuid: Optional[str]
+    patrolId: Optional[str]
+    incidentId: Optional[str]
+    incidentUuid: Optional[str]
+    team: Optional[str]
+    objective: Optional[str]
+    comment: Optional[str]
+    isArmed: Optional[str]
+    transportType: Optional[str]
+    mandate: Optional[str]
+    number: Optional[int]
+    members: Optional[List[str]]
+    leader: Optional[str]
+    attachments: Optional[List[File]]
+
+
+class Properties(BaseModel):
+    dateTime: Optional[datetime]
+    smartDataType: str
+    smartFeatureType: str
+    smartAttributes: Optional[Union[SmartObservation, SmartAttributes]]
+
+    class Config:
+        smart_union = True
+        json_encoders = {
+            datetime: lambda v: v.strftime(SMARTCONNECT_DATFORMAT)
+        }
+
+
+class SMARTRequest(BaseModel):
+    type: str = 'Feature'
+    geometry: Optional[Geometry]
+    properties: Properties
+
+
+class Waypoint(BaseModel):
+    attachments: List[Any]  # test what is contained here
+    conservation_area_uuid: str
+    date: date
+    id: str
+    client_uuid: Optional[str]
+    last_modified: datetime
+    observation_groups: List[Any]  # test
+    raw_x: float
+    raw_y: float
+    source: str
+    time: str
+
+
+class PatrolLeg(BaseModel):
+    client_uuid: str
+    end_date: date
+    id: str
+    mandate: dict
+    members: List[dict]
+    start_date = date
+    type: dict
+    uuid: str
+
+
+class Patrol(BaseModel):
+    armed: bool
+    attributes: Optional[List[Any]]  # Need to test what values are in here
+    client_uuid: str
+    comment: str
+    conservation_area: dict
+    end_date: date
+    id: str
+    start_date: date
+    team: Optional[dict]
+    uuid: str
+
+
+class SMARTResponseProperties(BaseModel):
+    fid: str
+    patrol: Optional[Patrol]
+    patrol_leg: Optional[PatrolLeg]
+    waypoint: Optional[Waypoint]
+
+
+class SMARTResponse(BaseModel):
+    type: str = 'Feature'
+    geometry: Geometry
+    properties: SMARTResponseProperties
+
+
+class Names(BaseModel):
+    name: str
+    locale: Optional[str]
+
+
+class ListOptions(BaseModel):
+    id: str
+    names: List[Names]
+
+
+class PatrolMetaData(BaseModel):
+    id: str
+    names: List[Names]
+    requiredWhen: Optional[str] = 'False'
+    listOptions: Optional[List[ListOptions]] = None
+    type: str
+
+
+class PatrolDataModel(BaseModel):
+    patrolMetadata: List[PatrolMetaData]
+
+
+class ConservationArea(BaseModel):
+    label: str
+    status: str
+    version: Optional[uuid.UUID]
+    revision: int
+    description: Optional[str]
+    designation: Optional[str]
+    organization: Optional[str]
+    pointOfContact: Optional[str]
+    location: Optional[str]
+    owner: Optional[str]
+    caBoundaryJson: Optional[str] = Field(None, description='A string containing GeoJSON')
+    administrativeAreasJson: Optional[Any]
+    uuid: uuid.UUID
+
+
+class SmartConnectApiInfo(BaseModel):
+    build_date: str = Field(None, alias='build-date')
+    build_version: str = Field(None, alias='build-version')
+    db_last_updated: str = Field(None, alias='db-last-updated')
+    file_store_version: str = Field(None, alias='file-store-version')
+    db_version: str = Field(None, alias='db-version')
+
+
+class SMARTCompositeRequest(BaseModel):
+    ca_uuid: str
+    patrol_requests: Optional[List[SMARTRequest]] = []
+    waypoint_requests: Optional[List[SMARTRequest]] = []
+    track_point_requests: Optional[List[SMARTRequest]] = []
+
+
+class SMARTUpdateRequest(BaseModel):
+    ca_uuid: str
+    waypoint_requests: Optional[List[SMARTRequest]] = []  # Only waypoints / incidents can be updated for now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.5.8"
+version = "1.5.9"
 
 description = ""
 authors = [


### PR DESCRIPTION
### What does this PR do?
- Adds models needed to support event updates in SMART, to be used by transformers and dispatchers.
- Makes some fields optional in models related to SMART so they can be used in other cases.
- Split schemas in separate files for ER and SMART

### Relevant link(s)
[GUNDI-2963](https://allenai.atlassian.net/browse/GUNDI-3297)
[GUNDI-2966](https://allenai.atlassian.net/browse/GUNDI-2966)


[GUNDI-2963]: https://allenai.atlassian.net/browse/GUNDI-2963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GUNDI-2966]: https://allenai.atlassian.net/browse/GUNDI-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ