### PR TITLE
GUNDI-3334: Add status field in Events

### DIFF
--- a/gundi_core/schemas/v2/gundi.py
+++ b/gundi_core/schemas/v2/gundi.py
@@ -157,6 +157,12 @@ class Event(GundiBaseModel):
     )
     observation_type: str = Field(StreamPrefixEnum.event.value, const=True)
 
+    status: Optional[str] = Field(
+        None,
+        title="Event status",
+        description="Events status, for example: 'new', 'resolved', etc...",
+    )
+
     @validator("recorded_at", allow_reuse=True)
     def clean_recorded_at(cls, val):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.6.1"
+version = "1.6.2"
 
 description = ""
 authors = [


### PR DESCRIPTION
### What does this PR do?
- Adds a `status` field in Events to support setting the status in events and updates going to ER sites

### Relevant link(s)
[GUNDI-3334](https://allenai.atlassian.net/browse/GUNDI-3334)

[GUNDI-3334]: https://allenai.atlassian.net/browse/GUNDI-3334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ