### PR TITLE
GUNDI-3565:  Action commands

### DIFF
--- a/gundi_core/commands/__init__.py
+++ b/gundi_core/commands/__init__.py
@@ -1,0 +1,2 @@
+from .core import *
+from .integrations import *

--- a/gundi_core/commands/core.py
+++ b/gundi_core/commands/core.py
@@ -1,0 +1,7 @@
+from gundi_core.events.core import SystemEventBaseModel
+
+
+class SystemCommandBaseModel(SystemEventBaseModel):
+    # Marker class for system commands.
+    # Technically, a command message is equal to an event message but expressing an intent.
+    pass

--- a/gundi_core/commands/integrations.py
+++ b/gundi_core/commands/integrations.py
@@ -1,0 +1,23 @@
+from typing import Optional, Dict, Any, Union
+from pydantic.fields import Field
+from uuid import UUID
+
+from .core import SystemCommandBaseModel
+
+
+class RunIntegrationAction(SystemCommandBaseModel):
+    integration_id: Union[UUID, str] = Field(
+        None,
+        title="Integration ID",
+        description="The unique ID of the Integration.",
+    )
+    action_id: str = Field(
+        None,
+        title="Action Identifier",
+        description="A string identifier of the action of the related integration.",
+    )
+    config_overrides: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Configuration",
+        description="A dictionary with the configuration used to execute the action",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.7.1"
+version = "1.8.0"
 
 description = ""
 authors = [


### PR DESCRIPTION
### What does this PR do?
- Extend base models to support commands as we move forward with an event-driven architecture.
- Model commands posted by the portal to run actions, to be consumed by the action runners

### Relevant link(s)
[GUNDI-3565](https://allenai.atlassian.net/browse/GUNDI-3565)


[GUNDI-3565]: https://allenai.atlassian.net/browse/GUNDI-3565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ