### PR TITLE
GUNDI-2981: Configuration events

### DIFF
--- a/gundi_core/events/__init__.py
+++ b/gundi_core/events/__init__.py
@@ -3,3 +3,4 @@ from .dispatchers import *
 from .integrations import *
 from .gundi_api import *
 from .transformers import *
+from .gundi_configs import *

--- a/gundi_core/events/core.py
+++ b/gundi_core/events/core.py
@@ -24,10 +24,15 @@ class SystemEventBaseModel(BaseModel):
         description="Event payload. This can be overwritten in more specific events",
     )
 
+    @property
+    def event_type(self) -> str:
+        # Read-only property that returns the class name as the event type
+        return self.__class__.__name__
+
     def dict(self, *args, **kwargs):
         # Add the event_type field with the class name
         json_dict = super().dict(*args, **kwargs)
-        json_dict["event_type"] = self.__class__.__name__
+        json_dict["event_type"] = self.event_type
         return json_dict
 
     def json(self, *args, **kwargs):

--- a/gundi_core/events/gundi_configs.py
+++ b/gundi_core/events/gundi_configs.py
@@ -1,5 +1,11 @@
 import pydantic
-from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, ConfigChanges, DeletionDetails
+from gundi_core.schemas.v2 import (
+    IntegrationSummary,
+    IntegrationActionConfiguration,
+    IntegrationConfigChanges,
+    ActionConfigChanges,
+    DeletionDetails
+)
 from .core import SystemEventBaseModel
 
 # Events published by the portal on config changes
@@ -8,10 +14,8 @@ from .core import SystemEventBaseModel
 class IntegrationCreated(SystemEventBaseModel):
     payload: IntegrationSummary
 
-
 class IntegrationUpdated(SystemEventBaseModel):
-    payload: ConfigChanges
-
+    payload: IntegrationConfigChanges
 
 class IntegrationDeleted(SystemEventBaseModel):
     payload: DeletionDetails
@@ -21,7 +25,7 @@ class ActionConfigCreated(SystemEventBaseModel):
     payload: IntegrationActionConfiguration
 
 class ActionConfigUpdated(SystemEventBaseModel):
-    payload: ConfigChanges
+    payload: ActionConfigChanges
 
 class ActionConfigDeleted(SystemEventBaseModel):
     payload: DeletionDetails

--- a/gundi_core/events/gundi_configs.py
+++ b/gundi_core/events/gundi_configs.py
@@ -4,7 +4,8 @@ from gundi_core.schemas.v2 import (
     IntegrationActionConfiguration,
     IntegrationConfigChanges,
     ActionConfigChanges,
-    DeletionDetails
+    IntegrationDeletionDetails,
+    ActionConfigDeletionDetails,
 )
 from .core import SystemEventBaseModel
 
@@ -18,7 +19,7 @@ class IntegrationUpdated(SystemEventBaseModel):
     payload: IntegrationConfigChanges
 
 class IntegrationDeleted(SystemEventBaseModel):
-    payload: DeletionDetails
+    payload: IntegrationDeletionDetails
 
 
 class ActionConfigCreated(SystemEventBaseModel):
@@ -28,4 +29,4 @@ class ActionConfigUpdated(SystemEventBaseModel):
     payload: ActionConfigChanges
 
 class ActionConfigDeleted(SystemEventBaseModel):
-    payload: DeletionDetails
+    payload: ActionConfigDeletionDetails

--- a/gundi_core/events/gundi_configs.py
+++ b/gundi_core/events/gundi_configs.py
@@ -1,0 +1,27 @@
+import pydantic
+from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, ConfigChanges
+from .core import SystemEventBaseModel
+
+# Events published by the portal on config changes
+
+
+class IntegrationCreated(SystemEventBaseModel):
+    payload: IntegrationSummary
+
+
+class IntegrationUpdated(SystemEventBaseModel):
+    payload: ConfigChanges
+
+
+class IntegrationDeleted(SystemEventBaseModel):
+    payload: IntegrationSummary
+
+
+class ActionConfigCreated(SystemEventBaseModel):
+    payload: IntegrationActionConfiguration
+
+class ActionConfigUpdated(SystemEventBaseModel):
+    payload: ConfigChanges
+
+class ActionConfigDeleted(SystemEventBaseModel):
+    payload: IntegrationActionConfiguration

--- a/gundi_core/events/gundi_configs.py
+++ b/gundi_core/events/gundi_configs.py
@@ -1,5 +1,5 @@
 import pydantic
-from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, ConfigChanges
+from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, ConfigChanges, DeletionDetails
 from .core import SystemEventBaseModel
 
 # Events published by the portal on config changes
@@ -14,7 +14,7 @@ class IntegrationUpdated(SystemEventBaseModel):
 
 
 class IntegrationDeleted(SystemEventBaseModel):
-    payload: IntegrationSummary
+    payload: DeletionDetails
 
 
 class ActionConfigCreated(SystemEventBaseModel):
@@ -24,4 +24,4 @@ class ActionConfigUpdated(SystemEventBaseModel):
     payload: ConfigChanges
 
 class ActionConfigDeleted(SystemEventBaseModel):
-    payload: IntegrationActionConfiguration
+    payload: DeletionDetails

--- a/gundi_core/schemas/v2/gundi.py
+++ b/gundi_core/schemas/v2/gundi.py
@@ -566,7 +566,7 @@ class WebhookConfiguration(BaseModel):
     data: Optional[Dict[str, Any]] = {}
 
 
-class ConfigChanges(pydantic.BaseModel):
+class ConfigChanges(BaseModel):
     id: Union[UUID, str] = Field(
         ...,
         title="ID",
@@ -616,6 +616,19 @@ class Integration(BaseModel):
         example="healthy",
         description="A human-readable string explaining the status of the integration",
     )
+
+    def get_action_config(self, action: str) -> IntegrationActionConfiguration:
+        """
+        Get the configuration for a specific action
+        :param action: The action value to get the configuration for. e.g. "auth", "pull_events", ...
+        """
+        return next(
+            (
+                config for config in self.configurations
+                if config.action.value == action
+            ),
+            None
+        )
 
 
 class IntegrationSummary(BaseModel):

--- a/gundi_core/schemas/v2/gundi.py
+++ b/gundi_core/schemas/v2/gundi.py
@@ -551,39 +551,6 @@ class IntegrationActionConfiguration(BaseModel):
     data: Optional[Dict[str, Any]] = {}
 
 
-# ToDo. delete if not needed
-# class ActionConfigInfo(BaseModel):
-#     id: Union[UUID, str] = Field(
-#         ...,
-#         title="Configuration ID",
-#         description="Id of the configuration",
-#     )
-#     action_id: Union[UUID, str] = Field(
-#         ...,
-#         title="Slug ID",
-#         description="Slug ID of an action in Gundi",
-#     )
-#     integration_id: Union[UUID, str] = Field(
-#         ...,
-#         title="Integration ID",
-#         description="Id of the integration that this configuration is for",
-#     )
-#     data: dict = Field(
-#         title="Configuration Values",
-#         description="A dictionary containing the configuration values",
-#         default_factory=dict
-#     )
-#
-#     @classmethod
-#     def from_integration_action_configuration(cls, action_config: IntegrationActionConfiguration):
-#         return cls(
-#             id=action_config.id,
-#             action_id=action_config.action.id,
-#             integration_id=action_config.integration,
-#             data=action_config.data
-#         )
-
-
 class WebhookConfiguration(BaseModel):
     id: Union[UUID, str] = Field(
         None,
@@ -597,46 +564,6 @@ class WebhookConfiguration(BaseModel):
     )
     webhook: IntegrationWebhookSummary
     data: Optional[Dict[str, Any]] = {}
-
-
-class IntegrationSummary(BaseModel):
-    id: Union[UUID, str] = Field(
-        ...,
-        title="Integration ID",
-        description="Id of an integration in Gundi",
-    )
-    name: Optional[str] = Field(
-        "",
-        example="X Data Provider for Y Reserve",
-        description="Route name",
-    )
-    type: IntegrationType
-    base_url: Optional[str] = Field(
-        "",
-        example="https://easterisland.pamdas.org/",
-        description="Base URL of the third party system associated with this integration.",
-    )
-    enabled: Optional[bool] = Field(
-        True,
-        example="true",
-        description="Enable/Disable this integration",
-    )
-    owner: Organization
-    default_route: Optional[ConnectionRoute]
-    additional: Optional[Dict[str, Any]] = {}
-
-    @classmethod
-    def from_integration(cls, integration: Integration):
-        return cls(
-            id=integration.id,
-            name=integration.name,
-            type=integration.type,
-            base_url=integration.base_url,
-            enabled=integration.enabled,
-            owner=integration.owner,
-            default_route=integration.default_route,
-            additional=integration.additional,
-        )
 
 
 class ConfigChanges(pydantic.BaseModel):
@@ -690,26 +617,45 @@ class Integration(BaseModel):
         description="A human-readable string explaining the status of the integration",
     )
 
+
+class IntegrationSummary(BaseModel):
+    id: Union[UUID, str] = Field(
+        ...,
+        title="Integration ID",
+        description="Id of an integration in Gundi",
+    )
+    name: Optional[str] = Field(
+        "",
+        example="X Data Provider for Y Reserve",
+        description="Route name",
+    )
+    type: IntegrationType
+    base_url: Optional[str] = Field(
+        "",
+        example="https://easterisland.pamdas.org/",
+        description="Base URL of the third party system associated with this integration.",
+    )
+    enabled: Optional[bool] = Field(
+        True,
+        example="true",
+        description="Enable/Disable this integration",
+    )
+    owner: Organization
+    default_route: Optional[ConnectionRoute]
+    additional: Optional[Dict[str, Any]] = {}
+
     @classmethod
-    def from_integration_summary(
-            cls, integration_info: IntegrationSummary,
-            configurations: List[IntegrationActionConfiguration]=None,
-            webhook_configuration: WebhookConfiguration=None,
-    ):
+    def from_integration(cls, integration: Integration):
         return cls(
-            id=integration_info.id,
-            name=integration_info.name,
-            type=integration_info.type,
-            base_url=integration_info.base_url,
-            enabled=integration_info.enabled,
-            owner=integration_info.owner,
-            default_route=integration_info.default_route,
-            additional=integration_info.additional,
-            configurations=configurations,
-            webhook_configuration=webhook_configuration,
+            id=integration.id,
+            name=integration.name,
+            type=integration.type,
+            base_url=integration.base_url,
+            enabled=integration.enabled,
+            owner=integration.owner,
+            default_route=integration.default_route,
+            additional=integration.additional,
         )
-
-
 
 # Earth Ranger Supported Actions & Configuration Schemas
 class EarthRangerActions(str, Enum):

--- a/gundi_core/schemas/v2/gundi.py
+++ b/gundi_core/schemas/v2/gundi.py
@@ -584,6 +584,18 @@ class ConfigChanges(BaseModel):
     )
 
 
+class IntegrationConfigChanges(ConfigChanges):
+    pass
+
+
+class ActionConfigChanges(ConfigChanges):
+    integration_id: Union[UUID, str] = Field(
+        ...,
+        title="Integration ID",
+        description="Id of the integration that this configuration is for",
+    )
+
+
 class DeletionDetails(BaseModel):
     id: Union[UUID, str] = Field(
         ...,

--- a/gundi_core/schemas/v2/gundi.py
+++ b/gundi_core/schemas/v2/gundi.py
@@ -551,6 +551,39 @@ class IntegrationActionConfiguration(BaseModel):
     data: Optional[Dict[str, Any]] = {}
 
 
+# ToDo. delete if not needed
+# class ActionConfigInfo(BaseModel):
+#     id: Union[UUID, str] = Field(
+#         ...,
+#         title="Configuration ID",
+#         description="Id of the configuration",
+#     )
+#     action_id: Union[UUID, str] = Field(
+#         ...,
+#         title="Slug ID",
+#         description="Slug ID of an action in Gundi",
+#     )
+#     integration_id: Union[UUID, str] = Field(
+#         ...,
+#         title="Integration ID",
+#         description="Id of the integration that this configuration is for",
+#     )
+#     data: dict = Field(
+#         title="Configuration Values",
+#         description="A dictionary containing the configuration values",
+#         default_factory=dict
+#     )
+#
+#     @classmethod
+#     def from_integration_action_configuration(cls, action_config: IntegrationActionConfiguration):
+#         return cls(
+#             id=action_config.id,
+#             action_id=action_config.action.id,
+#             integration_id=action_config.integration,
+#             data=action_config.data
+#         )
+
+
 class WebhookConfiguration(BaseModel):
     id: Union[UUID, str] = Field(
         None,
@@ -564,6 +597,59 @@ class WebhookConfiguration(BaseModel):
     )
     webhook: IntegrationWebhookSummary
     data: Optional[Dict[str, Any]] = {}
+
+
+class IntegrationSummary(BaseModel):
+    id: Union[UUID, str] = Field(
+        ...,
+        title="Integration ID",
+        description="Id of an integration in Gundi",
+    )
+    name: Optional[str] = Field(
+        "",
+        example="X Data Provider for Y Reserve",
+        description="Route name",
+    )
+    type: IntegrationType
+    base_url: Optional[str] = Field(
+        "",
+        example="https://easterisland.pamdas.org/",
+        description="Base URL of the third party system associated with this integration.",
+    )
+    enabled: Optional[bool] = Field(
+        True,
+        example="true",
+        description="Enable/Disable this integration",
+    )
+    owner: Organization
+    default_route: Optional[ConnectionRoute]
+    additional: Optional[Dict[str, Any]] = {}
+
+    @classmethod
+    def from_integration(cls, integration: Integration):
+        return cls(
+            id=integration.id,
+            name=integration.name,
+            type=integration.type,
+            base_url=integration.base_url,
+            enabled=integration.enabled,
+            owner=integration.owner,
+            default_route=integration.default_route,
+            additional=integration.additional,
+        )
+
+
+class ConfigChanges(pydantic.BaseModel):
+    id: Union[UUID, str] = Field(
+        ...,
+        title="ID",
+        description="Id of the record that changed in Gundi",
+    )
+    changes: dict = Field(
+        title="Data Changes",
+        description="A dictionary containing the changes made in the form 'field': 'value'.",
+        default_factory=dict
+    )
 
 
 class Integration(BaseModel):
@@ -603,6 +689,26 @@ class Integration(BaseModel):
         example="healthy",
         description="A human-readable string explaining the status of the integration",
     )
+
+    @classmethod
+    def from_integration_summary(
+            cls, integration_info: IntegrationSummary,
+            configurations: List[IntegrationActionConfiguration]=None,
+            webhook_configuration: WebhookConfiguration=None,
+    ):
+        return cls(
+            id=integration_info.id,
+            name=integration_info.name,
+            type=integration_info.type,
+            base_url=integration_info.base_url,
+            enabled=integration_info.enabled,
+            owner=integration_info.owner,
+            default_route=integration_info.default_route,
+            additional=integration_info.additional,
+            configurations=configurations,
+            webhook_configuration=webhook_configuration,
+        )
+
 
 
 # Earth Ranger Supported Actions & Configuration Schemas

--- a/gundi_core/schemas/v2/gundi.py
+++ b/gundi_core/schemas/v2/gundi.py
@@ -572,10 +572,28 @@ class ConfigChanges(BaseModel):
         title="ID",
         description="Id of the record that changed in Gundi",
     )
+    alt_id: Union[UUID, str] = Field(
+        None,
+        title="Alternative ID",
+        description="An alternative ID e.g. Slug ID or Custom ID",
+    )
     changes: dict = Field(
         title="Data Changes",
         description="A dictionary containing the changes made in the form 'field': 'value'.",
         default_factory=dict
+    )
+
+
+class DeletionDetails(BaseModel):
+    id: Union[UUID, str] = Field(
+        ...,
+        title="ID",
+        description="Id of the object that was deleted in Gundi",
+    )
+    alt_id: Union[UUID, str]  = Field(
+        None,
+        title="Alternative ID",
+        description="An alternative ID. e.g. Slug ID or Custom ID",
     )
 
 

--- a/gundi_core/schemas/v2/gundi.py
+++ b/gundi_core/schemas/v2/gundi.py
@@ -609,6 +609,18 @@ class DeletionDetails(BaseModel):
     )
 
 
+class IntegrationDeletionDetails(DeletionDetails):
+    pass
+
+
+class ActionConfigDeletionDetails(DeletionDetails):
+    integration_id: Union[UUID, str] = Field(
+        ...,
+        title="Integration ID",
+        description="Id of the integration that this configuration was for",
+    )
+
+
 class Integration(BaseModel):
     id: Union[UUID, str] = Field(
         None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.8.0"
+version = "1.8.1"
 
 description = ""
 authors = [


### PR DESCRIPTION
### What does this PR do?
- Adds models for configuration-related events, to be published by the portal and consumed by other services (event-driven architecture).
- Adds a helper function in the Integration model to get the configuration of a specific action

### Relevant link(s)
[GUNDI-2981](https://allenai.atlassian.net/browse/GUNDI-2981)

[GUNDI-2981]: https://allenai.atlassian.net/browse/GUNDI-2981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ