### PR TITLE
GUNDI-3559: Add more info in dispatcher error events

### DIFF
--- a/gundi_core/events/dispatchers.py
+++ b/gundi_core/events/dispatchers.py
@@ -1,5 +1,47 @@
+from typing import Optional
+from pydantic import BaseModel, Field
 from gundi_core.schemas.v2 import DispatchedObservation, UpdatedObservation, CustomDispatcherLog
 from .core import SystemEventBaseModel
+
+
+class DispatcherErrorDetails(BaseModel):
+    error: str = Field(
+        "",
+        title="Error",
+        description="A human-readable string describing the error.",
+    )
+    error_traceback: Optional[str] = Field(
+        "",
+        title="Error Traceback",
+        description="A string with the traceback of the error.",
+    )
+    server_response_status: Optional[int] = Field(
+        None,
+        title="Server Response Status",
+        description="The status code of the server response.",
+    )
+    server_response_body: Optional[str] = Field(
+        "",
+        title="Server Response",
+        description="The response from the server as text.",
+    )
+
+
+class DeliveryErrorDetails(DispatcherErrorDetails):
+    observation: Optional[DispatchedObservation] = Field(
+        None,
+        title="Observation",
+        description="The observation that caused the error.",
+    )
+
+
+class UpdateErrorDetails(DispatcherErrorDetails):
+    observation: Optional[UpdatedObservation] = Field(
+        None,
+        title="Observation",
+        description="The observation that caused the error.",
+    )
+
 
 # Events emmited by dispatchers
 
@@ -8,7 +50,8 @@ class ObservationDelivered(SystemEventBaseModel):
 
 
 class ObservationDeliveryFailed(SystemEventBaseModel):
-    payload: DispatchedObservation
+    schema_version: str = Field("v2", const=True)
+    payload: DeliveryErrorDetails
 
 
 class ObservationUpdated(SystemEventBaseModel):
@@ -16,7 +59,8 @@ class ObservationUpdated(SystemEventBaseModel):
 
 
 class ObservationUpdateFailed(SystemEventBaseModel):
-    payload: UpdatedObservation
+    schema_version: str = Field("v2", const=True)
+    payload: UpdateErrorDetails
 
 
 class DispatcherCustomLog(SystemEventBaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.8.1"
+version = "1.9.0"
 
 description = ""
 authors = [


### PR DESCRIPTION
### What does this PR do?
- Adds a new version of the dispatcher event models to store more info on errors including the traceback, server response status and response body. 

### Relevant link(s)
[GUNDI-3559](https://allenai.atlassian.net/browse/GUNDI-3559)

[GUNDI-3559]: https://allenai.atlassian.net/browse/GUNDI-3559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ