### PR TITLE
Fix location field names for ER messages

### DIFF
--- a/gundi_core/schemas/v2/earthranger.py
+++ b/gundi_core/schemas/v2/earthranger.py
@@ -105,6 +105,11 @@ class EREventUpdate(BaseModel):
         extra = "allow"  # To allow adding extra fields with field mappings
 
 
+class ERMessageLocation(BaseModel):
+    longitude: float = Field(..., title="Longitude in decimal degrees")
+    latitude: float = Field(..., title="Latitude in decimal degrees")
+
+
 class ERMessage(BaseModel):
     # Text messages sent to Earthranger
     message_type: str = Field(
@@ -127,7 +132,7 @@ class ERMessage(BaseModel):
         title="Message Timestamp",
         description="Timestamp when the message was sent or received.",
     )
-    device_location: Optional[ERObservationLocation] = Field(
+    device_location: Optional[ERMessageLocation] = Field(
         None,
         title="Device Location",
         description="Location of the device when the message was sent or received.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.11.1"
+version = "1.11.2"
 
 description = ""
 authors = [


### PR DESCRIPTION
This pull request introduces a new schema class for handling message locations in Earthranger messages, updates the `ERMessage` schema to use the new class, and increments the package version to reflect these changes.

### Schema updates:
* Added a new class `ERMessageLocation` in `gundi_core/schemas/v2/earthranger.py` to represent message locations with `longitude` and `latitude` fields.
* Updated the `device_location` field in the `ERMessage` schema to use the new `ERMessageLocation` class instead of `ERObservationLocation`.

### Version update:
* Incremented the package version in `pyproject.toml` from `1.11.1` to `1.11.2` to reflect the schema changes.