### PR TITLE
Add ReferenceDataItem and ReferenceDataKind schemas

### DIFF
--- a/gundi_core/schemas/v2/__init__.py
+++ b/gundi_core/schemas/v2/__init__.py
@@ -4,3 +4,4 @@ from .smart import *
 from .wpswatch import *
 from .traptagger import *
 from .inreach import *
+from .reference_data import *

--- a/gundi_core/schemas/v2/reference_data.py
+++ b/gundi_core/schemas/v2/reference_data.py
@@ -1,0 +1,86 @@
+"""Reference-data schemas — types used by destination-system provisioning.
+
+Stream records (observations, events, messages) carry slug values for
+`event_type`, `subject_type`, `subject_subtype`, `category`. The destination
+system (EarthRanger, SMART, etc.) must have rows provisioned that match
+those slugs or it rejects the record on POST. The dispatcher layer reads
+records, derives the set of `ReferenceDataItem`s a destination needs, and
+calls a destination-specific adapter to create them if missing.
+
+These schemas are the contract between cdip-routing's `ReferenceDataAdapter`
+Protocol and the per-destination dispatcher implementations.
+
+Phase 1 of the reference-data plan ships the lazy provisioning path inside
+the dispatcher only. Phase 2 will add a `ReferenceDataDeclaration` payload
+and a `ReferenceDataUpserted` system event so integrations can declare
+their catalog up-front; those additions belong in this module too when
+they land.
+"""
+from enum import Enum
+from typing import Any, Dict, Optional, Union
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ReferenceDataKind(str, Enum):
+    """The kind of reference-data row, used as a discriminator across destinations.
+
+    Each destination's adapter maps the kind to the appropriate API:
+    e.g. EarthRanger maps EVENT_TYPE → /activity/eventtypes/, SUBJECT_TYPE →
+    /subjecttypes/, etc.
+    """
+    EVENT_TYPE = "event_type"
+    SUBJECT_TYPE = "subject_type"
+    SUBJECT_GROUP = "subject_group"
+    CATEGORY = "category"
+
+
+class ReferenceDataItem(BaseModel):
+    """A single reference-data row a destination must have provisioned.
+
+    `value` is the slug used inside stream records (e.g. an event's
+    `event_type` field), and is the unique key the destination indexes on.
+
+    `attributes` carries kind-specific fields. The adapter for each
+    destination type knows which attributes it cares about; unknown
+    attributes are ignored by the adapter. Typical contents per kind:
+      - event_type:    display_name, default_priority, icon, color, category
+      - subject_type:  display_name, default_group, icon
+      - subject_group: display_name, members (list of subject ids)
+      - category:      display_name, parent_category
+    """
+    kind: ReferenceDataKind = Field(
+        ...,
+        description="Discriminator selecting the destination-side resource type.",
+    )
+    value: str = Field(
+        ...,
+        title="Slug",
+        description=(
+            "Stable identifier used inside stream records (e.g. 'tracpoint_speeding'). "
+            "Unique within (integration_id, kind)."
+        ),
+        min_length=1,
+        max_length=255,
+    )
+    integration_id: Union[UUID, str] = Field(
+        ...,
+        title="Source Integration ID",
+        description="The Gundi integration that declared (or emitted records referencing) this item.",
+    )
+    display_name: Optional[str] = Field(
+        "",
+        title="Display Name",
+        description=(
+            "Human-readable label shown in the destination UI. Adapter implementations "
+            "may fall back to a humanized form of `value` when this is empty."
+        ),
+    )
+    attributes: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Kind-specific fields (icon, color, default_priority, parent_category, "
+            "subject group members, etc.). See class docstring for typical contents."
+        ),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-core"
-version = "1.11.2"
+version = "1.12.0"
 
 description = ""
 authors = [


### PR DESCRIPTION
## Summary

Adds the data types the dispatcher layer needs to describe rows that destination systems (EarthRanger, SMART, etc.) must have provisioned for incoming stream records to be accepted. This is Phase 1 of the reference-data provisioning plan — the foundation that ` + "`cdip-routing`" + ` and the per-destination dispatcher repos build on.

## What lands

**New file:** ` + "`gundi_core/schemas/v2/reference_data.py`" + `

\`\`\`python
class ReferenceDataKind(str, Enum):
    EVENT_TYPE = "event_type"
    SUBJECT_TYPE = "subject_type"
    SUBJECT_GROUP = "subject_group"
    CATEGORY = "category"

class ReferenceDataItem(BaseModel):
    kind: ReferenceDataKind
    value: str                          # slug stream records use (e.g. "tracpoint_speeding")
    integration_id: Union[UUID, str]    # source integration that owns this
    display_name: Optional[str] = ""
    attributes: Dict[str, Any] = {}     # kind-specific fields (icon, color, members, ...)
\`\`\`

` + "`attributes`" + ` is deliberately a free-form dict so destination adapters can read kind-specific fields without forcing a new ` + "`gundi-core`" + ` release each time they want to consume something new (icon, default_priority, parent_category, group members, etc.).

Exported via ` + "`gundi_core/schemas/v2/__init__.py`" + ` alongside the existing per-destination schemas.

## What does NOT land in this PR

- ` + "`ReferenceDataUpserted`" + ` system event (Phase 2 — push declaration path)
- ` + "`ReferenceDataDeclaration`" + ` bulk upsert payload (Phase 2 — used by the integration → cdip upsert endpoint)
- Any cdip-routing adapter Protocol or EarthRanger adapter (separate PRs in their own repos)

Keeping this PR strictly to the schema types makes review fast and lets ` + "`cdip-routing`" + ` start importing ` + "`gundi-core==1.12.0`" + ` as soon as this merges and releases.

## Version

Bump ` + "`1.11.2`" + ` → ` + "`1.12.0`" + ` — additive public API, no breaking changes. Existing consumers of ` + "`gundi_core.schemas.v2`" + ` are unaffected.

## Test plan

- [x] Import surface verified locally:
  - ` + "`from gundi_core.schemas.v2 import ReferenceDataItem, ReferenceDataKind`" + ` resolves
  - All four kinds expose their string values (` + "`event_type`" + `, ` + "`subject_type`" + `, ` + "`subject_group`" + `, ` + "`category`" + `)
  - Round-trip JSON serialization of a populated ` + "`ReferenceDataItem`" + ` produces the expected shape
  - Pydantic rejects empty ` + "`value`" + ` (min_length=1)
- [ ] CI passes (no test suite exists in this repo today, so this is the import-validation step only)
- [ ] Tag ` + "`v1.12.0`" + ` and publish to PyPI so dependent repos can pin

## Followups

After this releases, the next PR is in ` + "`cdip-routing`" + ` — it adds:
- The ` + "`ReferenceDataAdapter`" + ` Protocol (typed against ` + "`ReferenceDataItem`" + `)
- The ` + "`ReferenceDataEnsureCache`" + ` (Redis-backed, per ` + "`(destination_id, kind, value)`" + ` keyed)
- The lazy hook in the existing observation/event delivery path

Per the plan at \`~/.claude/plans/i-prefer-to-make-wise-dolphin.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)